### PR TITLE
Added 60dB integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,23 @@ Listen to the demo here: [https://audio.com/troy-8/audio/troykelly-live-news-bre
 
 ## Speech Generation Notes
 
-We support generating your news read using OpenAI or ElevenLabs text to speech.
+We support generating your news read using OpenAI, ElevenLabs, or [60db](https://60db.ai) text to speech. Select the provider with `NEWS_READER_TTS_PROVIDER` (`openai`, `elevenlabs`, or `60db`).
 
 Although we support ElevenLabs, *DON'T USE IT* you will be wasting your time and money.
 
 ElevenLabs have absolutly no interest in their API users, and their voices aren't capable of reading a full news read.
 
 OpenAI's voices may stumble over a word or phrase, but trust me - ElevenLabs is a total waste of your time.
+
+### 60db
+
+60db is a text-to-speech provider that authenticates with a Bearer token and exposes a simple REST synthesis endpoint. To use it:
+
+1. Set `NEWS_READER_TTS_PROVIDER=60db`.
+2. Set `DB60_API_KEY` to your 60db API key.
+3. Set `NEWS_READER_TTS_VOICE` to a voice **name** (as it appears in your 60db account) or a `voice_id`. The script resolves names to ids automatically via the `GET https://api.60db.ai/myvoices` endpoint.
+
+Optional voice tuning is read from `60DB_*` environment variables (see the [60db section](#60db-configuration) below). Note that `NEWS_READER_TTS_MODEL` has no effect with 60db — the model is bound to the chosen voice. 60db also does not support cross-segment "request stitching", so each script segment is synthesized independently.
 
 ## Test
 
@@ -111,6 +121,9 @@ This section provides an overview and explanation of the environment variables u
 - **`ELEVENLABS_API_KEY`**: API key for ElevenLabs, used for TTS voice generation.
   - **Example:** `abc123`
 
+- **`DB60_API_KEY`**: API key for [60db](https://60db.ai), used for TTS voice generation when `NEWS_READER_TTS_PROVIDER=60db`.
+  - **Example:** `abc123`
+
 - **`NEWS_READER_CRON`**: Cron expression to schedule the news generation. If not set, the script runs once.
   - **Example:** `13,28,43,58 * * * *`
 
@@ -157,13 +170,28 @@ This section provides an overview and explanation of the environment variables u
   - **Default:** `tts-1`
   - **Example:** `tts-1-hd`
 
-- **`NEWS_READER_TTS_PROVIDER`**: TTS provider to use.
+- **`NEWS_READER_TTS_PROVIDER`**: TTS provider to use (`openai`, `elevenlabs`, or `60db`).
   - **Default:** `openai`
-  - **Example:** `elevenlabs`
+  - **Example:** `60db`
 
 - **`NEWS_READER_OUTPUT_FORMAT`**: Format for the output audio file.
   - **Default:** `flac`
   - **Example:** `mp3`
+
+### 60db Configuration
+
+These variables only apply when `NEWS_READER_TTS_PROVIDER=60db`. They are optional and map directly onto the 60db synthesis parameters (the `60DB_` prefix is stripped and the remainder is lower-cased). If unset, the documented 60db defaults are used.
+
+- **`60DB_STABILITY`**: Voice stability, `0`–`100` (lower = more expressive, higher = more consistent).
+  - **Default:** `50`
+- **`60DB_SIMILARITY`**: How closely the output matches the source voice, `0`–`100`.
+  - **Default:** `75`
+- **`60DB_SPEED`**: Speech speed multiplier, `0.5`–`2.0`.
+  - **Default:** `1`
+- **`60DB_ENHANCE`**: Enable audio enhancement (`true`/`false`).
+  - **Default:** `true`
+- **`60DB_OUTPUT_FORMAT`**: Per-segment synthesis format requested from 60db (`mp3`, `wav`, `ogg`, `flac`). This is decoded internally and does not change the final `NEWS_READER_OUTPUT_FORMAT`.
+  - **Default:** `wav`
 
 ### Audio Files
 

--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import base64
 import feedparser
 import openai
 import pytz
@@ -111,6 +112,9 @@ DEFAULT_CACHE_TTL = int(os.getenv("NEWS_READER_DEFAULT_CACHE_TTL", "3600"))
 
 # ElevenLabs Variable configuration
 ELEVENLABS_API_KEY = os.getenv("ELEVENLABS_API_KEY")
+
+# 60db Variable configuration
+DB60_API_KEY = os.getenv("DB60_API_KEY")
 
 # RSS Feed configuration
 FEED_CONFIG = {
@@ -1541,6 +1545,126 @@ def elevenlabs_segments_to_speech(
     return audio_segments
 
 
+def db60_segments_to_speech(
+    segments: List[str],
+    api_key: str,
+    voice: str,
+    model: str,
+    voice_settings: dict = {},
+) -> List[AudioSegment]:
+    """Generate speech using the 60db (https://60db.ai) TTS API.
+
+    Mirrors ``elevenlabs_segments_to_speech`` so the calling pipeline can treat
+    every provider identically: it accepts the same arguments and returns an
+    ordered list of normalized ``AudioSegment`` objects.
+
+    The 60db API authenticates with a Bearer token, resolves voices by id, and
+    returns audio as base64-encoded data inside a JSON envelope (unlike
+    ElevenLabs, which streams raw audio bytes). 60db does not support request
+    stitching, so each segment is synthesized independently.
+
+    Args:
+        segments (list of str): The phrases to be converted to speech.
+        api_key (str): 60db API key.
+        voice (str): Chosen voice name or voice_id for the TTS.
+        model (str): Unused by 60db (the model is bound to the voice); kept for
+            signature parity with the other providers.
+        voice_settings (dict): Optional overrides sourced from ``60DB_*``
+            environment variables, e.g. ``stability``, ``similarity``,
+            ``speed``, ``enhance``, ``output_format``.
+
+    Returns:
+        list of AudioSegment: Ordered list of `AudioSegment` objects representing
+        the converted phrases, or ``None`` if the voice list cannot be fetched.
+
+    Raises:
+        ValueError: If the named voice cannot be resolved to a voice_id.
+        RuntimeError: If a synthesis request fails.
+    """
+    api_url = "https://api.60db.ai"
+    api_endpoints = {
+        "voices": f"{api_url}/myvoices",
+        "synthesize": f"{api_url}/tts-synthesize",
+    }
+
+    api_headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    # Resolve the voice name to a voice_id. If the supplied value already looks
+    # like an id (i.e. it matches a voice_id directly), use it as-is.
+    try:
+        voices_response = requests.get(
+            api_endpoints["voices"], headers=api_headers)
+        voices_response.raise_for_status()
+        voices_data = voices_response.json()
+        db60_voices = voices_data.get("data", [])
+    except requests.RequestException as e:
+        logging.error(f"Failed to fetch data from 60db: {e}")
+        logging.error(traceback.format_exc())
+        return None
+
+    voice_id = next(
+        (
+            v["voice_id"]
+            for v in db60_voices
+            if v.get("name", "").lower() == voice.lower()
+            or v.get("voice_id") == voice
+        ),
+        None,
+    )
+    if not voice_id:
+        raise ValueError(
+            f"The specified voice '{voice}' does not exist in 60db.")
+
+    # Pull tunable parameters from voice_settings (populated from 60DB_* env
+    # vars), falling back to the documented 60db defaults.
+    output_format = str(voice_settings.get("output_format", "wav"))
+    speed = voice_settings.get("speed", 1)
+    stability = voice_settings.get("stability", 50)
+    similarity = voice_settings.get("similarity", 75)
+    enhance = voice_settings.get("enhance", True)
+
+    audio_segments: List[AudioSegment] = []
+
+    for i, segment in enumerate(segments):
+        response = requests.post(
+            api_endpoints["synthesize"],
+            json={
+                "text": segment,
+                "voice_id": voice_id,
+                "output_format": output_format,
+                "speed": speed,
+                "stability": stability,
+                "similarity": similarity,
+                "enhance": enhance,
+            },
+            headers=api_headers,
+        )
+
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"Error encountered, status: {response.status_code}, "
+                f"content: {response.text}"
+            )
+
+        payload = response.json()
+        if not payload.get("success") or not payload.get("audio_base64"):
+            raise RuntimeError(
+                f"60db synthesis failed for segment {i + 1}: "
+                f"{payload.get('message', 'no audio returned')}"
+            )
+
+        logging.info(f"Successfully converted segment {i + 1}/{len(segments)}")
+        audio_bytes = base64.b64decode(payload["audio_base64"])
+        audio_segment = AudioSegment.from_file(BytesIO(audio_bytes))
+        normalized_audio = audio_segment.apply_gain(-audio_segment.max_dBFS)
+        audio_segments.append(normalized_audio)
+
+    return audio_segments
+
+
 def generate_voice_options(provider_name):
     """Generate voice options for a specific TTS provider from environment variables.
 
@@ -1891,6 +2015,14 @@ def generate_news_audio():
             vo_segments = elevenlabs_segments_to_speech(
                 vo_segments_text,
                 ELEVENLABS_API_KEY,
+                tts_voice,
+                tts_model,
+                voice_provider_options,
+            )
+        elif tts_provider == "60db":
+            vo_segments = db60_segments_to_speech(
+                vo_segments_text,
+                DB60_API_KEY,
                 tts_voice,
                 tts_model,
                 voice_provider_options,


### PR DESCRIPTION
What we added  
  60db as a third TTS provider in src/main.py, alongside OpenAI and ElevenLabs:
  - New db60_segments_to_speech() function (Bearer auth, resolves voice name/id via /myvoices, synthesizes each segment via
  /tts-synthesize, base64-decodes → pydub).
  - DB60_API_KEY env var + a 60db branch in the provider dispatch.
  - import base64.
  - README updated with a 60db setup section and the 60DB_* config vars.

  How to use it

  DB60_API_KEY=your-60db-key
  NEWS_READER_TTS_PROVIDER=60db
  NEWS_READER_TTS_VOICE=YourVoiceName    # 60db voice name or voice_id

  # optional (defaults shown):
  60DB_STABILITY=50
  60DB_SIMILARITY=75
  60DB_SPEED=1
  60DB_ENHANCE=true
  60DB_OUTPUT_FORMAT=wav

  Then run: python src/main.py

  Note: NEWS_READER_TTS_MODEL is ignored for 60db (model is tied to the voice).